### PR TITLE
[fix] check is response json

### DIFF
--- a/lib/ya/api/direct/gateway.rb
+++ b/lib/ya/api/direct/gateway.rb
@@ -24,6 +24,16 @@ module Ya::API::Direct
       http.use_ssl = true
       http.verify_mode = @config[:ssl] ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
       response = http.request(request)
+
+      loop do
+        if response.kind_of?(Net::HTTPCreated) || response.kind_of?(Net::HTTPAccepted)
+          sleep response['retryIn'].to_i
+        else
+          break
+        end
+        response = http.request(request)
+      end
+
       if response.kind_of? Net::HTTPSuccess
         UrlHelper.parse_data response, ver
       else

--- a/lib/ya/api/direct/url_helper.rb
+++ b/lib/ya/api/direct/url_helper.rb
@@ -66,7 +66,7 @@ module Ya::API::Direct
     private
 
     def self.parse_data(response, ver)
-      if response["Content-Type"] == "application/json; charset=utf-8"
+      if response["Content-Type"].include?('application/json')
         response_body = JSON.parse(response.body)
         validate_response! response_body
         result = { data: response_body }


### PR DESCRIPTION
Apparently Yandex.direct does not returns charset for `ads.get` request.
Steps to reproduce:
1) Create on sandbox campaigns
2) Get campaigns
3) Get ads by ids from step 2.

```ruby
options = {
      token: authenticator.token,
      locale: 'ru',
      mode: :sandbox,
      cache: false
    }
direct = Ya::API::Direct::Client.new(options)
response = direct.campaigns.get('SelectionCriteria': { 'States': %w(ON OFF) }, 'FieldNames': %w[Id])
# responded with: application/json; charset=utf-8
campaigns = response.dig('result', 'Campaigns').map { |c| c['Id'] }
direct.ads.get('SelectionCriteria': { 'States': %w(ON OFF), 'CampaignIds': campaigns }, 'FieldNames': %w[Id])
# responded with: application/json; (and failed in *from_tsv_to_json*)
```