### PR TITLE
Fix: get last statistics row from tsv

### DIFF
--- a/lib/ya/api/direct/url_helper.rb
+++ b/lib/ya/api/direct/url_helper.rb
@@ -89,7 +89,7 @@ module Ya::API::Direct
     def self.from_tsv_to_json(response_body)
       report_name = response_body.slice!(/^(.+?)\n/)
       keys = response_body.slice!(/^(.+?)\n/).split("\t")
-      rows = response_body.match(/rows:(.+?)\n/)[1].to_i - 1
+      rows = response_body.match(/rows:(.+?)\n/)[1].to_i
       values = []
       rows.times do |row|
         hash_values = {}


### PR DESCRIPTION
> The last row in the report contains the number of rows with statistics.
> https://yandex.ru/dev/direct/doc/reports/report-format-docpage/?ncrnd=445

---------------

example (https://yandex.ru/dev/direct/doc/reports/example-docpage/)
![image](https://user-images.githubusercontent.com/26512193/64338110-ece4db00-cff1-11e9-95c6-c2d34453823e.png)
